### PR TITLE
fix: Add conflict check on reservation modification

### DIFF
--- a/Gestion.gs
+++ b/Gestion.gs
@@ -155,9 +155,17 @@ function mettreAJourDetailsReservation(idReservation, nouveauxArrets) {
     const { prix: nouveauPrix, duree: nouvelleDuree } = calculerPrixEtDureeServeur(nouveauxArrets + 1, retourPharmacie, dateEvenement, heureEvenement, clientPourCalcul);
     const nouveauxDetails = `Tournée de ${nouvelleDuree}min (${nouveauxArrets} arrêt(s) sup., retour: ${retourPharmacie ? 'oui' : 'non'})`;
 
+    const nouvelleDateFin = new Date(dateDebutOriginale.getTime() + nouvelleDuree * 60000);
+
+    // Ajout de la vérification de conflit
+    if (idEvenement) {
+        if (verifierConflitModification(dateDebutOriginale, nouvelleDateFin, idEvenement)) {
+            return { success: false, error: "La durée modifiée entre en conflit avec une autre réservation." };
+        }
+    }
+
     // Si l'événement existe, on le met à jour
     if (ressourceEvenement) {
-      const nouvelleDateFin = new Date(dateDebutOriginale.getTime() + nouvelleDuree * 60000);
       const ressourceMaj = {
         end: { dateTime: nouvelleDateFin.toISOString() },
         description: ressourceEvenement.description.replace(/Total:.*€/, `Total: ${nouveauPrix.toFixed(2)} €`).replace(/Arrêts suppl:.*\n/, `Arrêts suppl: ${nouveauxArrets}, Retour: ${retourPharmacie ? 'Oui' : 'Non'}\n`)


### PR DESCRIPTION
Prevents a user from extending a reservation in a way that overlaps with another existing event.

- Adds a new helper function `verifierConflitModification` to `Calendrier.gs` to check for overlaps, ignoring the event being modified.
- Modifies `mettreAJourDetailsReservation` in `Gestion.gs` to use this helper function and return an error if a conflict is detected.