### PR TITLE
fix: Remove reference to undefined variable in email template

### DIFF
--- a/Reservation.gs
+++ b/Reservation.gs
@@ -198,8 +198,6 @@ function notifierClientConfirmation(email, nom, reservations) {
             <p>Bonjour ${nom},</p>
             <p>Nous avons le plaisir de vous confirmer la réservation des tournées suivantes :</p>
 
-            <!-- <p><a href="${lienIcs}">Ajouter toutes les réservations à votre calendrier</a></p> -->
-
             <ul>
                 ${reservationsHtml}
             </ul>


### PR DESCRIPTION
This commit fixes a ReferenceError that occurred during email confirmation. The error was caused by a reference to an undefined variable `lienIcs` inside a template literal. Even though the reference was within an HTML comment, the JavaScript engine still evaluated it, leading to the error. The fix removes the line containing the reference from the email template.