### PR TITLE
feat: Prevent moving a tour to a past date

### DIFF
--- a/Client_JS.html
+++ b/Client_JS.html
@@ -184,12 +184,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const resa = toutesLesReservationsClient.find(r => r.id === idReservation);
         if (!resa || !contenuModale) return;
 
+        const aujourdhui = new Date().toISOString().split('T')[0];
+
         contenuModale.innerHTML = `
             <h3 id="modale-modification-titre">Déplacer la course</h3>
             <p><strong>Course actuelle :</strong> ${new Date(resa.start).toLocaleString('fr-FR')}</p>
             <div class="groupe-formulaire">
                 <label for="nouvelle-date">Nouvelle date :</label>
-                <input type="date" id="nouvelle-date" class="champ-formulaire">
+                <input type="date" id="nouvelle-date" class="champ-formulaire" min="${aujourdhui}">
             </div>
             <div class="groupe-formulaire">
                 <label>Nouveau créneau :</label>

--- a/Gestion.gs
+++ b/Gestion.gs
@@ -200,6 +200,16 @@ function replanifierReservation(idReservation, nouvelleDate, nouvelleHeure) {
   if (!lock.tryLock(30000)) return { success: false, error: "Le système est occupé." };
 
   try {
+    // --- Validation de la date ---
+    const aujourdhui = new Date();
+    aujourdhui.setHours(0, 0, 0, 0); // On ne compare que la date, pas l'heure
+    const dateVoulue = new Date(nouvelleDate);
+
+    if (dateVoulue < aujourdhui) {
+      return { success: false, error: "Vous ne pouvez pas déplacer une réservation à une date passée." };
+    }
+    // --- Fin de la validation ---
+
     const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
     const enTete = feuille.getRange(1, 1, 1, feuille.getLastColumn()).getValues()[0];
     const indices = {


### PR DESCRIPTION
This commit introduces validation to prevent clients from moving a tour to a past date from their client space.

- Adds server-side validation in `Gestion.gs` in the `replanifierReservation` function to reject any request where the new date is in the past.
- Adds client-side validation in `Client_JS.html` by setting the `min` attribute on the date input, preventing users from selecting a past date in the UI.