### PR TITLE
Fix(auth): Prevent magic link loop by allowing token reuse

### DIFF
--- a/Authentification.gs
+++ b/Authentification.gs
@@ -63,11 +63,13 @@ function verifierJetonMagique(token) {
       const ml = shML.getDataRange().getValues(); // A:Token B:URL C:Expiration D:Used
       for (let j = 1; j < ml.length; j++) {
         if (ml[j][0] === token) {
-          // Vérifie si le token a déjà été utilisé
-          if (ml[j][3] === true) {
-            return null; // Déjà utilisé
-          }
-          shML.getRange(j + 1, 4).setValue(true);
+          // On marque le jeton comme utilisé mais on ne bloque pas la connexion
+          // s'il a déjà été utilisé. Cela prévient les problèmes avec les scanners
+          // de liens dans les e-mails qui peuvent "utiliser" le jeton avant l'utilisateur.
+          // if (ml[j][3] === true) {
+          //   return null; // Déjà utilisé (DÉSACTIVÉ)
+          // }
+          shML.getRange(j + 1, 4).setValue(true); // On continue de marquer la première utilisation
           break;
         }
       }


### PR DESCRIPTION
The previous implementation used a strict single-use policy for magic link tokens. This caused a login loop for users whose email clients or security scanners pre-fetched the link, invalidating the token before the user could click it.

This change modifies the `verifierJetonMagique` function in `Authentification.gs` to remove the check that rejects an already-used token. The token is still marked as 'used' for auditing purposes, but it remains valid for its entire 15-minute lifespan. This makes the authentication process resilient to automated link scanners, resolving the login loop issue.