### PR TITLE
feat: Ajout de l'outil de génération de lien magique pour l'admin

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -33,6 +33,8 @@
       <button id="btn-ajouter-reservation" class="btn btn-primaire">Ajouter une course</button>
     </div>
 
+    <?!= include('Admin_MagicLink_Tool'); ?>
+
     <main id="conteneur-app">
       <div id="liste-reservations" class="carte">
         <h3 id="titre-reservations">Courses du jour</h3>

--- a/Admin_MagicLink_Tool.html
+++ b/Admin_MagicLink_Tool.html
@@ -1,0 +1,101 @@
+<div class="mlk-card">
+  <h3 class="mlk-title">Lien direct d’accès client (admin)</h3>
+
+  <div class="mlk-row">
+    <label class="mlk-label">E-mail du client</label>
+    <input type="email" class="mlk-input" data-mlk-email placeholder="client@exemple.fr">
+  </div>
+
+  <div class="mlk-actions">
+    <button class="mlk-pill" onclick="MLK_generate()">
+      Générer le lien
+    </button>
+  </div>
+
+  <div class="mlk-row" data-mlk-result style="display:none;">
+    <label class="mlk-label">Lien généré</label>
+    <input type="text" class="mlk-input" data-mlk-url readonly>
+    <button class="mlk-copy" onclick="MLK_copy()">Copier le lien</button>
+    <small class="mlk-help">
+      ⚠️ Lien à usage unique. Si le client clique deux fois, le second essai sera refusé.
+    </small>
+  </div>
+
+  <div class="mlk-toast" data-mlk-toast style="display:none;"></div>
+</div>
+
+<script>
+(function(){
+  window.MLK_generate = function(){
+    const emailEl = document.querySelector('[data-mlk-email]');
+    const resBox = document.querySelector('[data-mlk-result]');
+    const urlEl   = document.querySelector('[data-mlk-url]');
+    const toast   = document.querySelector('[data-mlk-toast]');
+    const email = (emailEl && emailEl.value || '').trim();
+
+    if (!email) { showToast('Saisis un e-mail valide.'); return; }
+
+    google.script.run
+      .withSuccessHandler(function(r){
+        if (r && r.ok) {
+          urlEl.value = r.url;
+          resBox.style.display = '';
+          showToast('Lien généré.');
+        } else {
+          showToast('Échec: ' + (r && r.error || '?'));
+        }
+      })
+      .withFailureHandler(function(err){ showToast('Erreur serveur: ' + err); })
+      .adminGenerateMagicLink(email);
+
+    function showToast(msg){
+      if (!toast) return;
+      toast.textContent = msg;
+      toast.style.display = 'block';
+      clearTimeout(window.__mlk_to);
+      window.__mlk_to = setTimeout(()=> toast.style.display = 'none', 3000);
+    }
+  };
+
+  window.MLK_copy = async function(){
+    const urlEl = document.querySelector('[data-mlk-url]');
+    const toast = document.querySelector('[data-mlk-toast]');
+    const text = (urlEl && urlEl.value) || '';
+    if (!text) return;
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // fallback
+        urlEl.select(); document.execCommand('copy');
+      }
+      if (toast){ toast.textContent = 'Copié dans le presse-papiers.'; toast.style.display = 'block';
+        clearTimeout(window.__mlk_to); window.__mlk_to = setTimeout(()=> toast.style.display = 'none', 2500); }
+    } catch(e) {
+      if (toast){ toast.textContent = 'Impossible de copier. Sélectionne le champ et copie manuellement.'; toast.style.display = 'block';
+        clearTimeout(window.__mlk_to); window.__mlk_to = setTimeout(()=> toast.style.display = 'none', 3500); }
+    }
+  };
+})();
+</script>
+
+<style>
+  .mlk-card{font-family:Monts
+
+errat,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:#fff;border:1px solid #e6e9ef;border-radius:16px;padding:16px;box-shadow:0 6px 20px rgba(0,0,0,.06)}
+  .mlk-title{margin:0 0 10px 0;font-weight:700;font-size:16px}
+  .mlk-row{margin:10px 0}
+  .mlk-label{display:block;margin-bottom:6px;font-weight:600;font-size:12px;color:#2c3e50}
+  .mlk-input{width:100%;padding:10px 12px;border:1px solid #d9deea;border-radius:12px;font-size:14px;outline:none}
+  .mlk-input:focus{border-color:#8e44ad;box-shadow:0 0 0 3px rgba(142,68,173,.12)}
+  .mlk-actions{margin-top:8px}
+  .mlk-pill{
+    display:inline-block;padding:10px 18px;border:none;border-radius:999px;
+    background:linear-gradient(90deg,#8e44ad,#3498db);color:#fff;font-weight:700;
+    cursor:pointer;box-shadow:0 6px 14px rgba(52,152,219,.25);transition:transform .05s ease,filter .2s ease}
+  .mlk-pill:hover{filter:brightness(1.05)}
+  .mlk-pill:active{transform:translateY(1px)}
+  .mlk-copy{margin-top:8px;padding:8px 12px;border:1px solid #cfd6e6;border-radius:10px;background:#f9fbff;cursor:pointer}
+  .mlk-help{display:block;margin-top:6px;color:#6b7280}
+  .mlk-toast{position:fixed;right:16px;bottom:16px;background:#5dade2;color:#fff;padding:10px 14px;border-radius:12px;box-shadow:0 8px 20px rgba(0,0,0,.15);font-weight:600}
+</style>

--- a/Debug.gs
+++ b/Debug.gs
@@ -183,11 +183,7 @@ function lancerTousLesTestsEtRetournerLogs() {
   return Logger.getLog();
 }
 
-function testMagicLink() {
+function testMagicLinkForSelf(){
   var email = Session.getActiveUser().getEmail() || 'elservicestoulon@gmail.com';
-  var token = createMagicToken(email);
-  var baseUrl = getConfiguration().WEBAPP_URL || ScriptApp.getService().getUrl();
-  var url = baseUrl + '?page=client&auth=' + encodeURIComponent(token);
-  Logger.log('TEST MAGIC LINK => ' + url);
-  return url;
+  return adminGenerateMagicLink(email);
 }


### PR DESCRIPTION
Ajoute une nouvelle fonctionnalité à l'interface d'administration permettant de générer un lien d'accès direct (lien magique) pour un client.

Cette modification comprend :
- Une nouvelle fonction `adminGenerateMagicLink` dans `Authentification.gs` pour créer le lien côté serveur sans envoyer d'email.
- Un nouveau widget HTML `Admin_MagicLink_Tool.html` contenant le formulaire de génération et de copie du lien.
- L'intégration de ce widget dans la page principale de l'administration (`Admin_Interface.html`).
- Une fonction de débogage `testMagicLinkForSelf` dans `Debug.gs` pour faciliter les tests.