### PR TITLE
feat: Create and update shema.gs with consolidated schemas

### DIFF
--- a/shema.gs
+++ b/shema.gs
@@ -1,0 +1,45 @@
+/**
+ * =================================================================
+ *                      DÉFINITION DES SCHÉMAS
+ * =================================================================
+ * Description: Ce fichier est la source unique de vérité pour la
+ *              structure (en-têtes de colonnes) de toutes les
+ *              feuilles de calcul utilisées par l'application.
+ *              Ce schéma a été consolidé pour supporter toutes les
+ *              fonctionnalités existantes dans le code.
+ * =================================================================
+ */
+
+const SCHEMAS = {
+  // Schéma consolidé pour supporter toutes les fonctions existantes
+  'Clients': [
+    "Email", "Raison Sociale", "Adresse", "SIRET", "TVA",
+    "Type de Remise", "Valeur Remise", "Nombre Tournées Offertes",
+    "CodeParrainage", "CodeUtilise", "CreditParrainage"
+  ],
+
+  // Schéma basé sur l'ancienne configuration, car il est utilisé par l'admin panel
+  'Destinataires': [
+    "Nom Complet", "Adresse", "Email", "Telephone", "Client Associé (Email)"
+  ],
+
+  // Schéma complet pour supporter la facturation, l'admin panel et l'espace client
+  'Facturation': [
+    "Date", "Client (Raison S. Client)", "Client (Email)", "Type", "Détails", "Montant",
+    "Statut", "Valider", "N° Facture", "Event ID", "ID Réservation", "ID PDF",
+    "Note Interne", "Lien Note", "Type Remise Appliquée", "Tournée Offerte Appliquée",
+    "Valeur Remise Appliquée", "Note Livreur", "Livreur Frigo", "Livreur Tampon",
+    "Livreur Reprise", "Livreur Extras"
+  ],
+
+  // Schéma requis pour la génération de factures
+  'Paramètres': [
+    "Clé", "Valeur", "Description"
+  ],
+
+  // Les schémas suivants sont définis pour assurer l'existence des feuilles.
+  // Leurs colonnes ne sont pas activement gérées par la logique de la même manière.
+  'Admin_Logs': [],
+  'Logs': [],
+  'Plages_Bloquees': ["Date", "Heure_Debut", "Heure_Fin"],
+};


### PR DESCRIPTION
This commit introduces the `shema.gs` file, which serves as the single source of truth for the structure of all spreadsheets used by the application.

The schemas have been defined after a thorough analysis of the codebase to ensure they are complete and accurate, reflecting the actual usage in the scripts.

- Created `shema.gs` with schemas for `Clients`, `Destinataires`, `Facturation`, `Paramètres`, `Admin_Logs`, `Logs`, and `Plages_Bloquees`.
- Removed unused schemas and columns to align with the current implementation.
- Corrected the name of the `Admin Logs` sheet to `Admin_Logs` to match its usage in the code.