### PR TITLE
Fix: Populate configServeur object in reservation interface

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -43,7 +43,12 @@
       appUrl: "<?= appUrl ?>",
       nomService: "<?= nomService ?>",
       URGENT_THRESHOLD_MINUTES: <?= URGENT_THRESHOLD_MINUTES || 45 ?>,
-      dateDuJour: "<?= dateDuJour ?>"
+      dateDuJour: "<?= dateDuJour ?>",
+      TARIFS: <?!= TARIFS_JSON ?>,
+      DUREE_BASE: <?= DUREE_BASE ?>,
+      DUREE_ARRET_SUP: <?= DUREE_ARRET_SUP ?>,
+      KM_BASE: <?= KM_BASE ?>,
+      KM_ARRET_SUP: <?= KM_ARRET_SUP ?>
     };
   </script>
 


### PR DESCRIPTION
The client-side reservation interface was failing to load server-side configuration, causing the error "Configuration du serveur non chargée. Utilisation de valeurs par défaut." (Server configuration not loaded. Using default values.).

This was because the `configServeur` JavaScript object in `Reservation_Interface.html` was not being initialized with all the necessary variables that the client-side scripts expect. The server-side code was already passing the required data (TARIFS, DUREE_BASE, etc.) to the template, but the template was not using them to construct the `configServeur` object.

This commit updates the script block in `Reservation_Interface.html` to correctly populate the `configServeur` object with all the required values. This makes the server configuration available to the client-side scripts and resolves the error.

Note: I was unable to run the automated test suite due to limitations in the execution environment that prevent interaction with the web-based test runner interface. However, the change is minimal, low-risk, and directly addresses the identified issue.