### PR TITLE
Fix: Correct filename for Client_Data_JS include

### DIFF
--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -62,10 +62,6 @@
     <div id="conteneur-notifications"></div>
   </div>
 
-audit-cleanup-auth
   <?!= include('Client_Data_JS'); ?>
-=======
-  <?!= include('Client_Data.js.html'); ?>
-> main
 </body>
 </html>


### PR DESCRIPTION
The application was failing to load the client management page ('gestion') due to an incorrect filename in an 'include' statement. This was caused by an unresolved merge conflict in 'Client_Espace.html'.

This commit resolves the merge conflict and corrects the filename to 'Client_Data_JS', which points to the existing 'Client_Data_JS.html' file. This allows the page to load correctly.