### PR TITLE
Fix(html): Add .html extension to ClientData include

### DIFF
--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -62,6 +62,6 @@
     <div id="conteneur-notifications"></div>
   </div>
 
-  <?!= include('ClientData'); ?>
+  <?!= include('ClientData.html'); ?>
 </body>
 </html>


### PR DESCRIPTION
The web app was failing to load the client management page (`page=gestion`) because the `Client_Espace.html` template was trying to include a file named `ClientData` instead of `ClientData.html`.

This resulted in a "fichier HTML non trouvé" (HTML file not found) error from the Google Apps Script `HtmlService`.

This commit corrects the filename in the `include` call within `Client_Espace.html` to include the required `.html` extension, resolving the error.