### PR TITLE
Fix: Correct user authentication for direct page access

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -161,6 +161,12 @@ function renderClientPage(e) {
       }
     }
 
+    // Si on n'a toujours pas d'email, on vérifie l'utilisateur connecté à Google.
+    // C'est le cas pour la page 'gestion' accédée directement par un admin/utilisateur loggué.
+    if (!email && Session.getActiveUser()) {
+        email = Session.getActiveUser().getEmail();
+    }
+
     var base = (getConfiguration().WEBAPP_URL || ScriptApp.getService().getUrl() || '').trim();
     base = base.split('#')[0].split('?')[0];
 


### PR DESCRIPTION
The 'gestion' page was showing a blank screen because the server-side `renderClientPage` function did not account for users accessing the page directly while logged into Google. It only handled authentication via URL tokens or session parameters.

This change adds a fallback to retrieve the user's email from the active Google session (`Session.getActiveUser().getEmail()`) if no token or session ID is present. This ensures that logged-in users are correctly identified, allowing the client-side scripts to load and display the page content as intended.