### PR TITLE
Restores the dynamic 'capsule' (gélule) styling for the calendar day …

### DIFF
--- a/src/Reservation_JS.html
+++ b/src/Reservation_JS.html
@@ -166,10 +166,10 @@ function afficherCalendrier(mois, annee) {
           const celluleJour = document.createElement('div');
           const date = new Date(annee, mois - 1, jour);
           const dateString = `${annee}-${String(mois).padStart(2, '0')}-${String(jour).padStart(2, '0')}`;
-          const disponibilite = window.etat.donneesCalendrier[dateString] || { disponibles: 0, total: 0 };
+          // Utiliser un total par défaut pour la cohérence visuelle si non fourni
+          const disponibilite = window.etat.donneesCalendrier[dateString] || { disponibles: 0, total: 8 };
 
-          celluleJour.className = 'jour-calendrier';
-          celluleJour.innerHTML = `<span>${jour}</span>`;
+          celluleJour.className = 'jour-capsule'; // Nouvelle classe pour le style "gélule"
 
           const estPasse = date < aujourdhui;
           const estDimanche = date.getDay() === 0;
@@ -177,13 +177,22 @@ function afficherCalendrier(mois, annee) {
 
           if (estPasse || estDimanche || estComplet) {
             celluleJour.classList.add('desactive');
+            celluleJour.innerHTML = `<span class="jour-numero">${jour}</span><span class="jour-dispo">Indisponible</span>`;
           } else {
             celluleJour.dataset.date = dateString;
-            celluleJour.setAttribute('aria-label', `${disponibilite.disponibles} créneaux disponibles`);
-            celluleJour.innerHTML += `
-              <div class="barre-disponibilite">
-                <div style="width:${(disponibilite.disponibles / disponibilite.total) * 100}%"></div>
-              </div>
+            celluleJour.setAttribute('aria-label', `${disponibilite.disponibles} sur ${disponibilite.total} créneaux disponibles`);
+
+            const placesPrises = disponibilite.total - disponibilite.disponibles;
+            // Le taux de remplissage est le pourcentage de places PRISES
+            const tauxRemplissage = disponibilite.total > 0 ? (placesPrises / disponibilite.total) * 100 : 0;
+
+            // Appliquer le dégradé dynamique suggéré
+            const bg = `linear-gradient(to right, var(--couleur-primaire) ${tauxRemplissage}%, var(--couleur-secondaire) ${tauxRemplissage}%)`;
+            celluleJour.style.background = bg;
+
+            celluleJour.innerHTML = `
+              <span class="jour-numero">${jour}</span>
+              <span class="jour-dispo">${disponibilite.disponibles} / ${disponibilite.total}</span>
             `;
           }
           grilleCalendrier.appendChild(celluleJour);

--- a/src/Style.html
+++ b/src/Style.html
@@ -92,6 +92,91 @@ body {
 
 
 /* =================================================================
+                      STYLES DU CALENDRIER
+   ================================================================= */
+
+#vue-calendrier .carte-en-tete {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+#vue-calendrier .btn-icone {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5em;
+  color: var(--gris-moyen);
+}
+
+#vue-calendrier #titre-calendrier {
+  font-size: 1.4em;
+  font-weight: 600;
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.calendrier-jours-semaine {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-weight: 600;
+  color: var(--gris-moyen);
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--couleur-bordure);
+}
+
+.grille-calendrier {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
+}
+
+.jour-capsule {
+  border-radius: 2em; /* Forme de gélule */
+  padding: 10px 5px;
+  color: white;
+  font-weight: 600;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 60px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+  position: relative;
+  border: 2px solid transparent;
+}
+
+.jour-capsule:not(.desactive):hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+}
+
+.jour-capsule.desactive {
+  background: #e9ecef !important; /* Surcharge le style en ligne */
+  color: #adb5bd;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.jour-numero {
+  font-size: 1.2em;
+  line-height: 1.2;
+}
+
+.jour-dispo {
+  font-size: 0.8em;
+  opacity: 0.9;
+  margin-top: 4px;
+}
+
+
+/* =================================================================
            STYLES SPÉCIFIQUES (DEPUIS Admin_CSS.html et Client_CSS.html)
            Ces styles ne s'appliquent que si la balise body a la classe "admin-scope"
    ================================================================= */


### PR DESCRIPTION
…view.

The previous implementation had lost the capsule styling, showing a raw list of days instead. This commit re-implements the dynamic rendering as requested.

- The `afficherCalendrier` function in `Reservation_JS.html` has been updated to generate a `div.jour-capsule` for each day. The background is now a `linear-gradient` that dynamically reflects the day's availability (fill level).
- New CSS rules have been added to `Style.html` for the `.jour-capsule` class to define its pill shape, shadow, hover effects, and styles for disabled states.

The changes were visually verified to ensure the calendar now correctly displays the dynamic, colored capsules.