### PR TITLE
fix(webapp): Correct server-side data injection

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -164,6 +164,7 @@ function doGet(e) {
     const template = HtmlService.createTemplateFromFile('Reservation_Interface');
     const config = getConfiguration();
 
+    template.publicConfig = getPublicConfig_();
     template.appUrl = ScriptApp.getService().getUrl();
     template.nomService = config.NOM_ENTREPRISE || "EL Services";
 

--- a/src/Reservation_Interface.html
+++ b/src/Reservation_Interface.html
@@ -193,7 +193,8 @@
 
 <!-- 1) variables pour le front en JSON, safe -->
 <script>
-  window.APP_CONFIG = <?!= JSON.stringify(getPublicConfig_()); ?>;
+  // Injection de la configuration publique, préparée côté serveur dans Code.gs
+  window.APP_CONFIG = <?!= JSON.stringify(publicConfig) ?>;
 </script>
 
 <!-- 2) tes scripts “maison” doivent être inclus DANS des balises script -->


### PR DESCRIPTION
Refactored the web app's data injection mechanism to prevent a client-side JavaScript parsing error. The error was caused by improperly calling a server-side function (`getPublicConfig_`) and `JSON.stringify` from within an HTML template scriptlet.

The fix implements a safer pattern:
1.  The server-side `doGet` function in `Code.gs` now explicitly fetches the configuration object.
2.  This object is passed as a property to the `HtmlTemplate` instance.
3.  The `Reservation_Interface.html` template now safely stringifies this server-provided variable, ensuring the generated JavaScript is always valid.

This resolves the "Uncaught SyntaxError: Unexpected token '='" and follows best practices for Google Apps Script web app development.