### PR TITLE
Fix: Correct SyntaxError from redeclared variable in Code.gs

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -163,7 +163,6 @@ function doGet(e) {
     // Page par défaut : Interface de réservation
     const template = HtmlService.createTemplateFromFile('Reservation_Interface');
     const config = getConfiguration();
-    const page = (e && e.parameter && e.parameter.page) ? e.parameter.page : 'reservation';
 
     template.public = {
       tarifs: getTarifsPublic().tarifs,
@@ -175,7 +174,9 @@ function doGet(e) {
         appUrl: ScriptApp.getService().getUrl()
       }
     };
-    template.page = page;
+    // Note: 'page' is declared at the top of the 'try' block.
+    // We provide a fallback here for when the URL parameter is absent.
+    template.page = page || 'reservation';
 
     return template.evaluate()
         .setTitle((config.NOM_ENTREPRISE || "EL Services") + " | Réservation")


### PR DESCRIPTION
This commit fixes a `SyntaxError: Identifier 'page' has already been declared` that was introduced in the previous commit.

The error was caused by redeclaring the `page` constant within the same block scope in the `doGet` function.

The fix removes the second declaration and instead reuses the existing `page` variable, providing a fallback default value when assigning it to the template.

---
Previous commit message:

Refactor data injection to prevent XSS and fix errors

This commit refactors the way data is passed from the server-side Apps Script to the client-side JavaScript. It addresses potential cross-site scripting (XSS) vulnerabilities and a 'SyntaxError: Unexpected token =' error.

The key changes are:
- The `doGet` function in `Code.gs` now injects a single, properly serialized `public` object into the front-end. This object contains all necessary initial data like tariffs and UI settings.
- The main HTML interface (`Reservation_Interface.html`) has been updated to receive this data into a global `window.__PUBLIC__` object, using `JSON.stringify` for safety.
- Client-side JavaScript (`Reservation_JS.html`) has been refactored to read from this global object instead of making insecure `google.script.run` calls to fetch configuration on the fly.
- Redundant data-fetching functions on the client-side have been removed.
- A global cleanup was performed to ensure no `document.write` calls or other insecure scriptlet interpolations exist in the project.

Note: The project's unit tests are designed for the Google Apps Script environment and could not be run in the current sandbox. The changes were carefully implemented to preserve the existing business logic.