### PR TITLE
Fix: Correct syntax errors in Style.html

### DIFF
--- a/src/Style.html
+++ b/src/Style.html
@@ -6,6 +6,7 @@
  * Les styles de la page de réservation sont les styles par défaut.
  * Les styles pour les pages Admin et Client sont préfixés par
  * une classe `.admin-scope` pour éviter les conflits.
+*/
 /* =================================================================
 
 
@@ -205,9 +206,6 @@ body {
   0% { transform: scale(0.92) translateY(60px); opacity: 0; }
   100% { transform: scale(1) translateY(0); opacity: 1; }
 }
-
-
- main
 
 /* =================================================================
            STYLES SPÉCIFIQUES (DEPUIS Admin_CSS.html et Client_CSS.html)


### PR DESCRIPTION
This commit fixes two issues in the main stylesheet (`src/Style.html`):
1. An unclosed CSS comment at the top of the file, which caused subsequent styles to be ignored.
2. A stray `main` keyword in the middle of the file, which was a CSS syntax error.

These errors were the likely cause of the 'broken HTML' issue reported by the user.